### PR TITLE
Use multilint on both Python 2 and 3, remove unnecessary nose-parameterized

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 docutils
 flake8
-nose-parameterized
+multilint
 Pillow
 Pygments
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docutils==0.12
 enum34==1.1.6             # via flake8
 flake8==3.0.4
 mccabe==0.5.2             # via flake8
-nose-parameterized==0.5.0
+multilint==1.0.2
 Pillow==3.3.1
 py==1.4.31                # via pytest
 pycodestyle==2.0.0        # via flake8

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ requirements = [
 setup(
     name='treepoem',
     version=version,
-    description="Barcode rendering for Python 2 and 3 supporting QRcode, Aztec, PDF417, I25, Code128, Code39 and many more types.",
+    description="Barcode rendering for Python 2 and 3 supporting QRcode, "
+                "Aztec, PDF417, I25, Code128, Code39 and many more types.",
     long_description=readme + '\n\n' + history,
     author="Christian Muirhead",
     author_email='xtian@babbageclunk.com',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py27, py33, py34, py35
+envlist = py{27,35}-codestyle, py{27,35}
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
@@ -8,8 +8,10 @@ deps =
 changedir = {toxinidir}/tests
 commands = py.test
 
-[testenv:lint]
+[testenv:py27-codestyle]
 changedir = {toxinidir}
-commands =
-    flake8 treepoem tests
-    python setup.py check -s --restructuredtext --metadata
+commands = multilint
+
+[testenv:py35-codestyle]
+changedir = {toxinidir}
+commands = multilint


### PR DESCRIPTION
And fix one lint error in `setup.py`.