### PR TITLE
setup.cfg - it's [bdist_wheel] not [wheel]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 max-line-length = 130
-
-[wheel]
-universal = 1


### PR DESCRIPTION
`[wheel]` is deprecated.