### PR TITLE
Determine the ghostscript command on windows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@
 History
 -------
 
+* Support Windows.
+
 1.0.1
 ------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,10 @@ import re
 import subprocess
 import sys
 
-from treepoem import _gs_command
+from treepoem import GS_COMMAND
 
-GS = _gs_command()
 
-GHOSTSCRIPT_VERSION = subprocess.check_output([GS, '--version']).decode('utf-8')
+GHOSTSCRIPT_VERSION = subprocess.check_output([GS_COMMAND, '--version']).decode('utf-8')
 if not re.match(r'9\.\d\d', GHOSTSCRIPT_VERSION):
     print(
         "Ghostscript must be version 9.X, have {}".format(GHOSTSCRIPT_VERSION)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,11 @@ import re
 import subprocess
 import sys
 
+from treepoem import _gs_command
 
-GHOSTSCRIPT_VERSION = subprocess.check_output(['gs', '--version']).decode('utf-8')
+GS = _gs_command()
+
+GHOSTSCRIPT_VERSION = subprocess.check_output([GS, '--version']).decode('utf-8')
 if not re.match(r'9\.\d\d', GHOSTSCRIPT_VERSION):
     print(
         "Ghostscript must be version 9.X, have {}".format(GHOSTSCRIPT_VERSION)

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -58,6 +58,7 @@ EPS_TEMPLATE = """\
 
 """ + BASE_PS
 
+
 def _gs_command():
     if sys.platform != 'win32':
         return 'gs'
@@ -80,7 +81,7 @@ def _gs_command():
         return cmd
 
     return 'gswin32c'
-        
+
 
 BBOX_COMMAND = [_gs_command(), '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
 

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -59,29 +59,14 @@ EPS_TEMPLATE = """\
 """ + BASE_PS
 
 
-def _gs_command():
-    if sys.platform != 'win32':
-        return 'gs'
+GS_COMMAND = 'gs'
 
-    # On Windows, command `gs` is replaced by either `gswin32c` or `gswin64c`.
-    # See https://ghostscript.com/doc/current/Use.htm#MS_Windows
-    try:
-        # Has executable been defined by 'gssetgs.bat'?
-        return os.environ['GSC']
-    except KeyError:
-        pass
-
-    # Try launching 64bit version. If that fails, assume 32bit.
-    cmd = 'gswin64c'
-    try:
-        subprocess.check_call([cmd, '-dBATCH', '-q'])
-    except OSError:
-        cmd = 'gswin32c'
-
-    return cmd
+if sys.platform.startswith('win'):
+    from PIL.EpsImagePlugin import gs_windows_binary
+    GS_COMMAND = gs_windows_binary
 
 
-BBOX_COMMAND = [_gs_command(), '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
+BBOX_COMMAND = [GS_COMMAND, '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
 
 
 class TreepoemError(RuntimeError):

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import codecs
 import io
 import os
+import sys
 import subprocess
 
 from PIL.EpsImagePlugin import EpsImageFile
@@ -57,7 +58,31 @@ EPS_TEMPLATE = """\
 
 """ + BASE_PS
 
-BBOX_COMMAND = ['gs', '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
+def _gs_command():
+    if sys.platform != 'win32':
+        return 'gs'
+
+    # platform is Windows
+    try:
+        # has executable been defined by 'gssetgs.bat'?
+        cmd = os.environ['GSC']
+    except KeyError:
+        pass
+    else:
+        return cmd
+
+    cmd = 'gswin64c'
+    try:
+        subprocess.check_call([cmd, '-dBATCH'])
+    except Exception:
+        pass
+    else:
+        return cmd
+
+    return 'gswin32c'
+        
+
+BBOX_COMMAND = [_gs_command(), '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
 
 
 class TreepoemError(RuntimeError):

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -63,24 +63,22 @@ def _gs_command():
     if sys.platform != 'win32':
         return 'gs'
 
-    # platform is Windows
+    # On Windows, command `gs` is replaced by either `gswin32c` or `gswin64c`.
+    # See https://ghostscript.com/doc/current/Use.htm#MS_Windows
     try:
-        # has executable been defined by 'gssetgs.bat'?
-        cmd = os.environ['GSC']
+        # Has executable been defined by 'gssetgs.bat'?
+        return os.environ['GSC']
     except KeyError:
         pass
-    else:
-        return cmd
 
+    # Try launching 64bit version. If that fails, assume 32bit.
     cmd = 'gswin64c'
     try:
         subprocess.check_call([cmd, '-dBATCH'])
-    except Exception:
-        pass
-    else:
-        return cmd
+    except OSError:
+        cmd = 'gswin32c'
 
-    return 'gswin32c'
+    return cmd
 
 
 BBOX_COMMAND = [_gs_command(), '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -74,7 +74,7 @@ def _gs_command():
     # Try launching 64bit version. If that fails, assume 32bit.
     cmd = 'gswin64c'
     try:
-        subprocess.check_call([cmd, '-dBATCH'])
+        subprocess.check_call([cmd, '-dBATCH', '-q'])
     except OSError:
         cmd = 'gswin32c'
 


### PR DESCRIPTION
Addresses issue #43.

If the platform is Windows, tries to determine the GhostScript command name by checking for the `GSC` environment variable, then trying the different possibilities.