### PR TITLE
Improve testing for CLI

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,72 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+
+import pytest
+
+from treepoem.__main__ import main
+
+
+def test_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['treepoem', '--help'])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 0
+    out, err = capsys.readouterr()
+    assert 'Supported barcode types are: auspost,' in out
+    assert err == ''
+
+
+def test_simple(tmpdir, monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['treepoem', '-o', str(tmpdir.join('test.png')), 'barcodedata'])
+    main()
+    assert tmpdir.join('test.png').check(exists=True)
+
+
+def test_stdout(tmpdir, monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['treepoem', 'barcodedata'])
+    main()
+    out, err = capsys.readouterr()
+    print(out)
+    print(err)
+    out_lines = out.splitlines()
+    assert out_lines[:3] == [
+        # xbm format
+        '#define im_width 86',
+        '#define im_height 86',
+        'static char im_bits[] = {',
+    ]
+    assert err == ''
+
+
+def test_stdout_with_format(tmpdir, monkeypatch, capfdbinary):
+    monkeypatch.setattr(sys, 'argv', ['treepoem', '-f', 'png', 'barcodedata'])
+    main()
+    out, err = capfdbinary.readouterr()
+    assert out.startswith(b'\x89PNG')  # PNG magic bytes
+    assert err == b''
+
+
+def test_unsupported_barcode_type(tmpdir, monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['treepoem', '-t', 'invalid-barcode-type',
+                                      '-o', str(tmpdir.join('test.png')), 'barcodedata'])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+    assert tmpdir.join('test.png').check(exists=False)
+    out, err = capsys.readouterr()
+    assert out == ''
+    assert 'Barcode type "invalid-barcode-type" is not supported.' in err
+
+
+def test_unsupported_file_format(tmpdir, monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['treepoem', '-f', 'invalid-image-format',
+                                      '-o', str(tmpdir.join('test.bin')), 'barcodedata'])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+    assert tmpdir.join('test.bin').check(exists=False)
+    out, err = capsys.readouterr()
+    assert out == ''
+    assert 'Image format "invalid-image-format" is not supported' in err

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -8,7 +8,6 @@ import pytest
 from PIL import EpsImagePlugin, Image, ImageChops
 
 import treepoem
-from treepoem.__main__ import main
 
 
 @pytest.mark.parametrize('barcode_type,barcode_data', [
@@ -78,25 +77,3 @@ def test_unsupported_barcode_type():
     with pytest.raises(NotImplementedError) as excinfo:
         treepoem.generate_barcode('invalid-barcode-type', '')
     assert 'unsupported barcode type' in str(excinfo.value)
-
-
-def test_cli_simple(tmpdir, monkeypatch):
-    monkeypatch.setattr(sys, 'argv', ['treepoem', '-o', str(tmpdir.join('test.png')), 'barcodedata'])
-    main()
-    assert tmpdir.join('test.png').check(exists=True)
-
-
-def test_cli_unsupported_barcode_type(tmpdir, monkeypatch):
-    monkeypatch.setattr(sys, 'argv', ['treepoem', '-t', 'invalid-barcode-type',
-                                      '-o', str(tmpdir.join('test.png')), 'barcodedata'])
-    with pytest.raises(SystemExit):
-        main()
-    assert tmpdir.join('test.png').check(exists=False)
-
-
-def test_cli_unsupported_file_format(tmpdir, monkeypatch):
-    monkeypatch.setattr(sys, 'argv', ['treepoem', '-f', 'invalid-image-format',
-                                      '-o', str(tmpdir.join('test.bin')), 'barcodedata'])
-    with pytest.raises(SystemExit):
-        main()
-    assert tmpdir.join('test.bin').check(exists=False)

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@ envlist = py{27,36}-codestyle, py{27,36}
 install_command = pip install --no-deps {opts} {packages}
 deps =
     -rrequirements.txt
-changedir = {toxinidir}/tests
-commands = py.test
+commands = pytest {posargs}
 
 [testenv:py27-codestyle]
 changedir = {toxinidir}


### PR DESCRIPTION
* Place CLI tests in a separate test file
* Make CLI also support `python -m treepoem`
* Determine default is stdout at runtime rather than import time to make output capturing possible
* Add tests for `--help`
* Add asserts on output
* Make `SystemExit` asserts check the return code as well
* Add checks for stdout code path
* Add asserts on output in failure tests
* Fix formatting of error output like `Barcode type u'invalid-barcode-type' is not supported.` on Python 2 by not using `%r`, or even any deprecated %-based string formatting