### PR TITLE
Fix formatting bug in CLI output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,13 @@ History
 
 .. Insert new release notes below this line
 
+* Fix formatting bug in CLI output.
+
 1.4.0 (2018-05-01)
 ------------------
 
-* Make the ``options`` argument to ``generate_barcode`` optional
-* Add a CLI ``treepoem``
+* Make the ``options`` argument to ``generate_barcode`` optional.
+* Add a CLI ``treepoem``.
 * Upgrade BWIPP from 2017-07-10 to 2017-10-19. This has a few bug fixes and
   performance improvements. You can read its changelog in the vendored copy in
   the `treepoem repo

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,7 +57,7 @@ def test_unsupported_barcode_type(tmpdir, monkeypatch, capsys):
     assert tmpdir.join('test.png').check(exists=False)
     out, err = capsys.readouterr()
     assert out == ''
-    assert 'Barcode type "invalid-barcode-type" is not supported.' in err
+    assert 'Barcode type "invalid-barcode-type" is not supported. Supported barcode types are:' in err
 
 
 def test_unsupported_file_format(tmpdir, monkeypatch, capsys):

--- a/treepoem/__main__.py
+++ b/treepoem/__main__.py
@@ -35,7 +35,7 @@ def main():
     args = parser.parse_args()
 
     if args.type not in barcode_types:
-        parser.error('Barcode type "{}" is not supported. %s'.format(args.type, supported_barcode_types))
+        parser.error('Barcode type "{}" is not supported. {}'.format(args.type, supported_barcode_types))
 
     try:
         stdout_binary = sys.stdout.buffer


### PR DESCRIPTION
The supported barcode types weren't output on invalid type due to broken conversion from `%` formatting to `.format()`